### PR TITLE
Quelch too-many-arguments warning on `make_rpc_bench_threads`

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -456,6 +456,7 @@ fn run_rpc_bench_loop(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn make_rpc_bench_threads(
     rpc_benches: Vec<RpcBench>,
     mint: &Option<Pubkey>,


### PR DESCRIPTION
#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
